### PR TITLE
Derponarium

### DIFF
--- a/derp.asd
+++ b/derp.asd
@@ -2,7 +2,7 @@
   :description "derp"
   :author "dptd <dptdescribe@gmail.com>"
   :license "MIT"
-  :depends-on (#:jasa #:cl-json #:cl-ppcre #:cxml)
+  :depends-on (#:jasa #:cl-json #:cl-ppcre #:cxml #:cl-async #:bordeaux-threads)
   :serial t
   :components ((:file "package")
                (:file "derp")

--- a/derp.asd
+++ b/derp.asd
@@ -8,5 +8,6 @@
                (:file "derp")
                (:file "commands")
                (:file "queues")
-               (:file "requests")))
+               (:file "requests")
+               (:file "derponarium")))
 

--- a/derponarium.lisp
+++ b/derponarium.lisp
@@ -1,7 +1,44 @@
 (in-package #:derponarium)
 
-(defclass derponarium ()
-  ((derps :initarg :token
-          :accessor token
-          :initform nil
-          :documentation "Active derps.")))
+;; hashtable: derp name + derp channel -> derp instance, thread and running
+
+(defstruct derp-thread
+  (derp-instance nil)
+  (thread nil)
+  (running nil))
+
+(setf *derps* nil)
+
+(defun prehash (derp)
+  "Returns string based on derp name and channel."
+  (concatenate 'string
+               (slot-value derp 'derp::name)
+               (slot-value derp 'derp::channel)))
+
+(defun add-derp (derp)
+  (setf *derps* (cons (cons
+                       (prehash derp)
+                       (derponarium::make-derp-thread :derp-instance derp
+                                                      :thread nil
+                                                      :running nil))
+                      *derps*)))
+
+(defun find-derp (derp)
+  (if (stringp derp)
+      (assoc derp *derps* :test 'string=)
+      (error "Must be a string.")))
+
+(defun get-derp (derp)
+  (if (stringp derp)
+      (derp-thread-derp-instance (cdr (find-derp derp)))
+      (error "Must be a string.")))
+
+;; (defun start-derp (derp)
+;;   (if (stringp derp)
+;;       (progn
+;;         (bt:make-thread (derp:start-derping (get-derp derp)))
+;;         (derp-thread-thread (find-derp derp))
+;;       (error "Must be a string.")))
+
+(defun stop-derp (derp)
+  ())

--- a/derponarium.lisp
+++ b/derponarium.lisp
@@ -7,7 +7,7 @@
   (thread nil)
   (running nil))
 
-(setf *derps* nil)
+(defvar *derps* nil)
 
 (defun prehash (derp)
   "Returns string based on derp name and channel."
@@ -25,8 +25,13 @@
                           *derps*))
       (error "Parameter must be an instance of a derp class.")))
 
+(defun remove-derp (derp)
+  (if (running-p derp)
+      (stop-derp derp))
+  (setf *derps* (remove-if #'(lambda (x) (string= derp (car x))) *derps*)))
+
 (defun find-derp (derp)
-  (if (stringp derp)o
+  (if (stringp derp)
       (assoc derp *derps* :test 'string=)
       (error "Parameter must be a string.")))
 
@@ -35,15 +40,25 @@
       (derp-thread-derp-instance (cdr (find-derp derp)))
       (error "Parameter must be a string.")))
 
-(defun start-derp (derp)
+(defun running-p (derp)
   (if (stringp derp)
       (if (find-derp derp)
-          (progn
-            (setf (derp-thread-thread (cdr (find-derp derp))) (bt:make-thread (lambda ()
-                                                                          (derp:start-derping (get-derp derp)))))
-            (setf (derp-thread-running (cdr (find-derp derp))) t))
+          (derp-thread-running (cdr (find-derp derp)))
           (error (format nil "Cannot find derp named: ~A." derp)))
       (error "Must be a string.")))
 
+(defun start-derp (derp)
+  (if (not (running-p derp))
+      (progn
+        (setf (derp-thread-thread (cdr (find-derp derp))) (bt:make-thread (lambda ()
+                                                                            (derp:start-derping (get-derp derp)))))
+        (setf (derp-thread-running (cdr (find-derp derp))) t))
+      (error (format nil "Derp named: ~A is already running." derp))))
+
 (defun stop-derp (derp)
-  ())
+  (if (running-p derp)
+      (progn
+        (bt:destroy-thread (derp-thread-thread (cdr (find-derp derp))))
+        (setf (derp-thread-thread (cdr (find-derp derp))) nil)
+        (setf (derp-thread-running (cdr (find-derp derp))) nil))
+      (error (format nil "Derp named: ~A is not running." derp))))

--- a/derponarium.lisp
+++ b/derponarium.lisp
@@ -16,29 +16,34 @@
                (slot-value derp 'derp::channel)))
 
 (defun add-derp (derp)
-  (setf *derps* (cons (cons
-                       (prehash derp)
-                       (derponarium::make-derp-thread :derp-instance derp
-                                                      :thread nil
-                                                      :running nil))
-                      *derps*)))
+  (if (typep derp 'derp::derp)
+      (setf *derps* (cons (cons
+                           (prehash derp)
+                           (derponarium::make-derp-thread :derp-instance derp
+                                                          :thread nil
+                                                          :running nil))
+                          *derps*))
+      (error "Parameter must be an instance of a derp class.")))
 
 (defun find-derp (derp)
-  (if (stringp derp)
+  (if (stringp derp)o
       (assoc derp *derps* :test 'string=)
-      (error "Must be a string.")))
+      (error "Parameter must be a string.")))
 
 (defun get-derp (derp)
   (if (stringp derp)
       (derp-thread-derp-instance (cdr (find-derp derp)))
-      (error "Must be a string.")))
+      (error "Parameter must be a string.")))
 
-;; (defun start-derp (derp)
-;;   (if (stringp derp)
-;;       (progn
-;;         (bt:make-thread (derp:start-derping (get-derp derp)))
-;;         (derp-thread-thread (find-derp derp))
-;;       (error "Must be a string.")))
+(defun start-derp (derp)
+  (if (stringp derp)
+      (if (find-derp derp)
+          (progn
+            (setf (derp-thread-thread (cdr (find-derp derp))) (bt:make-thread (lambda ()
+                                                                          (derp:start-derping (get-derp derp)))))
+            (setf (derp-thread-running (cdr (find-derp derp))) t))
+          (error (format nil "Cannot find derp named: ~A." derp)))
+      (error "Must be a string.")))
 
 (defun stop-derp (derp)
   ())

--- a/derponarium.lisp
+++ b/derponarium.lisp
@@ -1,0 +1,7 @@
+(in-package #:derponarium)
+
+(defclass derponarium ()
+  ((derps :initarg :token
+          :accessor token
+          :initform nil
+          :documentation "Active derps.")))

--- a/package.lisp
+++ b/package.lisp
@@ -15,4 +15,5 @@
   (:export requests request-command))
 
 (defpackage #:derponarium
-  (:use #:cl #:derp))
+  (:use #:cl #:derp)
+  (:export add-derp remove-derp start-derp stop-derp))

--- a/package.lisp
+++ b/package.lisp
@@ -13,3 +13,6 @@
 (defpackage #:derp.requests
   (:use #:cl #:jasa.chat)
   (:export requests request-command))
+
+(defpackage #:derponarium
+  (:use #:cl #:derp))


### PR DESCRIPTION
This package should allow to spawn derps in different threads. It exports `add-derp`, `remove-derp`, `start-derp` and `stop-derp`.

It stores information about currently created derps in a list `*derps*`. Derps are named based on the channel where they are spawned and derp name (see function `prehash`).